### PR TITLE
Update ship class translation.

### DIFF
--- a/cn/localisation/l_english.yml
+++ b/cn/localisation/l_english.yml
@@ -3389,7 +3389,7 @@
  buildable_none:0 "无效"
  buildable_money:0 "能量点数"
 
- BUILDABLE_SHIP_NAME:0 "$TYPE$类别"
+ BUILDABLE_SHIP_NAME:0 "$TYPE$级"
  LEFT_CLICK_BUILDABLES:0 "§G点击查看建筑列表§!"
 
  TIMED_MOD_DESC:0 "$TITLE|H$\n$DESC$\n$EFFECTS$\n$DAYS$ 日剩余"


### PR DESCRIPTION
在舰船建造界面目前目前显示的是xx类别。事实上舰船的class应该翻译为xx级，例如[衣阿华级战列舰](https://zh.wikipedia.org/wiki/%E8%A1%A3%E9%98%BF%E5%8D%8E%E7%BA%A7%E6%88%98%E5%88%97%E8%88%B0)。