### PR TITLE
Curator -> 守护者

### DIFF
--- a/cn/localisation/guardian_l_english.yml
+++ b/cn/localisation/guardian_l_english.yml
@@ -280,18 +280,18 @@
 
 ### CURATORS
 
- guardian.500.name:0 "博物馆署"
+ guardian.500.name:0 "守护者"
  guardian.500a.desc:0 "或许你正在想我身后的壁画上的图形是什么意思。这是个好问题，这里有个有趣的答案！这条信息的价格是 15 万亿能源点。"
  guardian.502.name:0 "和[From.GetName]的第一次接触"
- guardian.502a.desc:0 "你好，星际旅行者。这里是博物馆署。\n\n在遥远的过去，银河的统治势力给我们下达了命令，让我们用生命去保护所有的知识，捍卫银河不要再次遭受灭绝之祸，阻止世界进入野蛮的黑暗世纪。\n\n我们失败了。\n\n到了今天，我们的人所剩无几，但我们比先辈们在履行神圣的任务方面更加坚定。我们想和你分享一点知识……有偿的。"
- guardian.502b.desc:0 "很高兴遇见你，探险者。你正在和[From.GetName]通话。获悉你已经对我们古老命令的信条很熟悉了。和在其它博物馆署中的那些令人尊重的同僚一样，只要你付得起价钱，我们很乐意做交易。"
+ guardian.502a.desc:0 "你好，星际旅行者，我们是守护者。\n\n在遥远的过去，银河的统治势力给我们下达了命令，让我们用生命去保护所有的知识，捍卫银河不要再次遭受灭绝之祸，阻止世界进入野蛮的黑暗世纪。\n\n我们失败了。\n\n到了今天，我们的人所剩无几，但我们比先辈们在履行神圣的任务方面更加坚定。我们想和你分享一点知识……有偿的。"
+ guardian.502b.desc:0 "很高兴遇见你，探险者。你正在和[From.GetName]通话。获悉你已经对我们古老命令的信条很熟悉了。和在其它守护者中的那些令人尊重的同僚一样，只要你付得起价钱，我们很乐意做交易。"
  guardian.502.a:0 "很高兴遇见你。"
  
- guardian.500b.desc:0 "你已抵达博物馆署。我们应该如何协助您？"
+ guardian.500b.desc:0 "你已来访守护者。我们应该如何协助您？"
  guardian.500c.desc:0 "你可知道这次会谈已经被来自七个亚空间领域的存在物近距离监视着？哎，恐怕和他们沟通来做些对你有好处的事情所需要用到的科技已经远超你们的文明现在能做到的上限。"
  guardian.500d.desc:0 "不用害怕。我们将在未来的几个世代里跟踪 [Root.GetName] 的信息存入档案。你们的国家分崩离析后还会被记住很久。"
  guardian.500e.desc:0 "我有很多事情想告诉你，可惜我不能免费做这些。这个太空基地需要很多的能源来运转……我们必须考虑我们的开销。"
- guardian.500f.desc:0 "这是来自博物馆社团的问候。这儿有什么你想要的？"
+ guardian.500f.desc:0 "这是来自守护者势力的问候。这儿有什么你想要的？"
  guardian.500g.desc:0 "和过去一样，为您的政府效劳是我们的荣幸。请允许我们向您展示一些有趣的科技？"
  guardian.500h.desc:0 "见到你真好。我相信今天内我们就可以达成一些对彼此有利的协议。"
  guardian.500i.desc:0 "知识一旦掌握在错误的手中就会变得危险，但是我们能做什么？我们需要能量保持光明……"
@@ -301,11 +301,11 @@
  
  guardian.500.a:0 "我们有兴趣采购一些星图。"
  guardian.500.b:0 "能为我们的科研提供协助吗？"
- guardian.500.b.alreadyaided:0 "博物馆署已经提供了科研协助服务。"
+ guardian.500.b.alreadyaided:0 "守护者已经提供了科研协助服务。"
  guardian.500.c:0 "请告诉我们关于这个宇宙的秘密。"
  guardian.500.d:0 "我们可以雇佣一位你们的科学家吗？"
- guardian.500.d.alreadyrecruited:0 "我们已经雇佣了一位博物馆署的科学家。"
- guardian.500.d.opinion:0 "评价需求 §Y博物馆署§! ：\n£opinion  评价 +50"
+ guardian.500.d.alreadyrecruited:0 "我们已经雇佣了一位守护者科学家。"
+ guardian.500.d.opinion:0 "§Y守护者§! 需要：\n£opinion  评价 +50"
  guardian.500.e:0 "再见。"
  
  guardian.506.name:0 "星图"
@@ -323,7 +323,7 @@
  guardian.507.a.reply:0 "真是明智的选择，未来 [Root.GetSpeciesNamePlural] 一定会感谢您这次的选择。"
  
  guardian.508.name:0 "奥秘"
- guardian.508.desc:0 "在银河中心的星系中潜伏着一些极其强大的东西。在付出了包括生命和资源在内的极大代价后，博物馆署特工艰难的获取了一些知识。这些知识会让你下次遇到这些东西后，对付它们起来容易一些。"
+ guardian.508.desc:0 "在银河中心的星系中潜伏着一些极其强大的东西。在付出了包括生命和资源在内的极大代价后，守护者的特工艰难的获取了一些知识。这些知识会让你下次遇到这些东西后，对付它们起来容易一些。"
  guardian.508.a:0 "告诉我们一些还不知道的事情。"
  guardian.508.a.reply:0 "这个或许让你有兴趣……我们已经你的§Y情报日志§!中标出了星系。"
  guardian.508.b:0 "告诉我们有关$guardian.510.name$的事。" #ether drake
@@ -344,7 +344,7 @@
  guardian.597a.desc:0 "蠢货！攻击我们会导致你的未来几个世代都会沦落到生活在低科技的苦难中！"
  guardian.597b.desc:0 "你的本能驱使你攻击我们，而现在你必须付出代价。我们再也不会和 [Root.GetName] 分享知识。"
  guardian.597c.desc:0 "我们给了你们这么多，[Root.GetSpeciesName]，然而你将其全部抛弃。真是人渣野蛮人！"
- guardian.597d.desc:0 "你已被认为是整个博物馆社团的敌人。"
+ guardian.597d.desc:0 "你已被认为是整个守护者势力的敌人。"
 
  guardian.510.name:0 "以太龙兽"  # Drake
  guardian.510.desc:0 "以太龙兽这个种族不像我们宇宙中的生命。终极巨龙非常强大，但并非不可战胜。"
@@ -421,7 +421,7 @@
  guardian.594.cd.desc.start:0 "与 [From.GetName] 完全失去了联系，我们的侦测设备确认古老的博物基地已经被摧毁。"
  guardian.594.cd.desc.known:0 "凶手是来自 [curator_destroyer.GetName] 的部队。"
  guardian.594.cd.desc.unknown:0 "动手的是不明势力。"
- guardian.594.cd.desc.trade:0 "很不幸地，这也意味着我们失去了对访问庞大博物馆署数据库的全部权限。"
+ guardian.594.cd.desc.trade:0 "很不幸地，这也意味着我们失去了对访问庞大守护者数据库的全部权限。"
  guardian.594.a:0 "这对他们的遗产真是个悲伤的结局。"
  guardian.594.b:0 "这使我们付出了巨大的代价！"
 
@@ -726,8 +726,8 @@
  enclave_traders_sr2:0 "旭然集团贸易订单"
  enclave_traders_sr3:0 "穆塔钢贸易订单"
 
- opinion_destroyed_curator:0 "被摧毁的博物飞地"
- opinion_destroyed_curator_insight:0 "被摧毁的曾经有过交流的博物馆署"
+ opinion_destroyed_curator:0 "被摧毁的守护者飞地"
+ opinion_destroyed_curator_insight:0 "被摧毁的曾经有过交流的守护者势力"
  opinion_destroyed_trader:0 "被摧毁的贸易飞地"
  opinion_destroyed_trader_sr:0 "被摧毁的曾经有过交流的贸易组织"
 
@@ -772,16 +772,16 @@
  damage_vs_country_type_guardian_hiver_mult:0 "对小行星蜂巢的伤害"
 
  curator_buff_stellarite:0 "耗散噬星者"
- curator_buff_stellarite_desc:0 "博物馆署要求我们攻击噬星者的调节阀门以消散它内部的热量。"
+ curator_buff_stellarite_desc:0 "守护者要求我们攻击噬星者的调节阀门以消散它内部的热量。"
  curator_buff_sphere:0 "无极校准仪"
  curator_buff_sphere_desc:0 "无极机器的实时预警更新系统有一个弱点。它无法应对持续的变化。我们今后将在每艘舰船上安排一名持续校准武器的船员。"
  damage_vs_country_type_guardian_stellarite_mult:0 "对噬星者造成的伤害"
  damage_vs_country_type_guardian_sphere_mult:0 "对无极机器造成的伤害"
 
  curator_poi_chain_title:0 "宇宙的奥秘"
- curator_poi_chain_desc:1 "博物馆署知道许多事。我们可以基于想做的事情向他们购买信息。“
+ curator_poi_chain_desc:1 "守护者知道许多事。我们可以基于想做的事情向他们购买信息。“
  curator_poi_title:1 "兴趣点"
- curator_poi_desc:1 "我们向博物馆署购买了这些坐标 - 据称这些地方有些有趣的东西。"
+ curator_poi_desc:1 "我们向守护者购买了这些坐标 - 据称这些地方有些有趣的东西。"
 
  technosphere_chain_title:0 "高科技球体"
  technosphere_chain_desc:0 "§Y高康大黑洞§!旁一个闪耀的金属球。它现在纹丝不动，但他会永远保持这样吗？"

--- a/terms_list.txt
+++ b/terms_list.txt
@@ -26,7 +26,7 @@ Materialistic - 物质主义(的)
 Neutral - 中立
 
 # 事件名词
-Curators - 博物馆署
+Curators - 守护者
 Riggan - 瑞玵
 XuraCorp - 旭然集团
 Muutagan - 穆塔钢


### PR DESCRIPTION
结合上下文想了一下，还是放弃了监察者这个翻译，用守护者，意指“知识守护者”