### PR TITLE
Update event_chains_l_english.yml

### DIFF
--- a/cn/localisation/english/event_chains_l_english.yml
+++ b/cn/localisation/english/event_chains_l_english.yml
@@ -160,5 +160,5 @@
 
  refugees.1.name:0 "[Root.GetSpeciesName]的难民已抵达"
  refugees.1.desc.1:0 "搭载[Root.GetSpeciesName]难民的民用运输舰队从[RefugeeEscapedFrom.GetName]来到了我们的领地。他们已经获准在§H[Root.Planet.GetName]§!上安居。\n\n这些不幸的受逐者被[RefugeeEscapedFrom.GetSpeciesName]当局强制驱离出家。自那以来，他们一直在恒星系之间旅行， 绝望地努力在最后的补给物资用完之前找到新家。"
- refugees.1.desc.2:0 "搭载[Root.GetSpeciesNamePlural]难民的破旧民用运输舰队从[RefugeeEscapedFrom.GetName]来到了我们的领地。他们已经获准在§H[Root.Planet.GetName]§!上安居。\n\n这些衣衫褴褛的难民是[RefugeeEscapedFrom.GetSpeciesName]当局实施种族清洗政策的幸存者。他们凭借着一个仓促的地下铁路和一些富有同情心的商人船长的努力才完成大脱逃。"
+ refugees.1.desc.2:0 "搭载[Root.GetSpeciesNamePlural]难民的破旧民用运输舰队从[RefugeeEscapedFrom.GetName]来到了我们的领地。我们为难民提供了食物和医疗照顾，同时他们被获准在§H[Root.Planet.GetName]§!上安居。\n\n这些衣衫褴褛的难民是[RefugeeEscapedFrom.GetSpeciesName]当局实施种族清洗政策的幸存者。他们能够脱逃还需要感谢一个匆忙组建起来的地下解救组织和一些富有同情心的商船船长。"
  refugees.1.a:0 "欢迎他们前来"


### PR DESCRIPTION
 After we supplied them with food and provided medical attention to their wounded, 他们已经获准在§H[Root.Planet.GetName]§!上安居
增加前段“after...wounded”的翻译内容。

underground railroad翻译内容更改
原翻译为“仓促的地下铁路”，不符合中文习惯，underground railroad最早是只美国南方黑奴通过一些地下铁路逃离奴隶主，后来随着借此逃奴的规模越来越大，“地下铁路”也泛指帮助逃奴的组织。但是中国没有帮助逃奴的地下铁路，所以我觉得用地下铁路直译不太妥当，翻译其后来衍生出来的“帮助逃奴组织”的含义比较好。结合文意，翻译为地下解救组织。