### PR TITLE
pu

### DIFF
--- a/cn/localisation/english/l_english.yml
+++ b/cn/localisation/english/l_english.yml
@@ -6579,7 +6579,7 @@
  civic_tooltip_agrarian_idyll_effects:0 "£building  §Y水培农场§!额外多产出§Y1§!点 £unity  凝聚力。"
  civic_tooltip_mechanists_effects:1 "以能建造机器人的科技开始游戏，并有§Y4§!个 £pop  起始人口替换为机器人。"
  civic_tooltip_syncretic_evolution_effects:1 "以一个额外的奴仆物种开始游戏，并有§Y4§!个 £pop  起始人口替换为该奴仆物种。"
- civic_tooltip_fanatic_purifiers_effects:1 "无法和其他物种的帝国进行§Y外交§!！\n§Y外星人口§!必定会被肃清，而且外星人口不影响传统成本。\n肃清 £pop  外星人口能获得 £unity  §Y凝聚力§!。\n可以使用§Y$GROUND_SUPPORT_STANCE_ARMAGEDDON$§!轨道轰炸模式。\n§Y$MOD_SHIP_FIRE_RATE_MULT$§!获得§G+33%§!\n§Y$MOD_ARMY_DAMAGE_MULT$§!获得§G+33%§!"
+ civic_tooltip_fanatic_purifiers_effects:1 "无法和其他物种的帝国进行§Y外交§!！\n§Y外星人口§!必定会被肃清，而且外星奴隶不影响传统成本。\n肃清 £pop  外星人口能获得 £unity  §Y凝聚力§!。\n可以使用§Y$GROUND_SUPPORT_STANCE_ARMAGEDDON$§!轨道轰炸模式。"
  
  civic_tooltip_spiritualist:0 "拥有§Y精神主义§!"
  civic_tooltip_materialist:0 "拥有§Y物质主义§!"


### PR DESCRIPTION
1.5.1以后，就算一个公民性有一个自定义的效果描述，它的调整因素描述也依然会显现。于是1.5.1起狂心肃清者的描述就成了这样：

```
无法和其他物种的帝国进行§Y外交§!！
§Y外星人口§!必定会被肃清，而且外星人口不影响传统成本。
肃清 £pop  外星人口能获得 £unity  §Y凝聚力§!。
可以使用§Y$GROUND_SUPPORT_STANCE_ARMAGEDDON$§!轨道轰炸模式。
§Y$MOD_SHIP_FIRE_RATE_MULT$§!获得§G+33%§!
§Y$MOD_ARMY_DAMAGE_MULT$§!获得§G+33%§!
§W$MOD_SHIP_FIRE_RATE_MULT$§!: §G+33%§!
§W$MOD_ARMY_DAMAGE_MULT$§!: §G+33%§!
```

所以把这段冗余文字去了，游戏里看着舒服点。